### PR TITLE
ENH: Add a skip decorator

### DIFF
--- a/asv_runner/benchmarks/_base.py
+++ b/asv_runner/benchmarks/_base.py
@@ -519,14 +519,7 @@ class Benchmark:
         )
 
         # Fetch skip parameters
-        skip_dict = _get_first_attr(attr_sources, "skip_params", {})
-
-        # Create list of tuples of parameter combinations to be skipped
-        self._skip_tuples = [
-            (value, key)
-            for key, values in skip_dict.items()
-            for value in (values if isinstance(values, list) else [values])
-        ]
+        self._skip_tuples = _get_first_attr(attr_sources, "skip_params", [])
 
         # Exported parameter representations
         self.params = _unique_param_ids(self._params)

--- a/asv_runner/benchmarks/_base.py
+++ b/asv_runner/benchmarks/_base.py
@@ -219,7 +219,7 @@ def _get_sourceline_info(obj, basedir):
         return ""
 
 
-def check_num_args(root, benchmark_name, func, min_num_args, max_num_args=None):
+def _check_num_args(root, benchmark_name, func, min_num_args, max_num_args=None):
     """
     Verifies if the function under benchmarking accepts a correct number of arguments.
 
@@ -548,22 +548,22 @@ class Benchmark:
         max_num_args = min_num_args
 
         if self.setup_cache_key is not None:
-            ok = ok and check_num_args(
+            ok = ok and _check_num_args(
                 root, f"{self.name}: setup_cache", self._setup_cache, 0
             )
             max_num_args += 1
 
         for setup in self._setups:
-            ok = ok and check_num_args(
+            ok = ok and _check_num_args(
                 root, f"{self.name}: setup", setup, min_num_args, max_num_args
             )
 
-        ok = ok and check_num_args(
+        ok = ok and _check_num_args(
             root, f"{self.name}: call", self.func, min_num_args, max_num_args
         )
 
         for teardown in self._teardowns:
-            ok = ok and check_num_args(
+            ok = ok and _check_num_args(
                 root,
                 f"{self.name}: teardown",
                 teardown,

--- a/asv_runner/benchmarks/helpers.py
+++ b/asv_runner/benchmarks/helpers.py
@@ -1,0 +1,9 @@
+from functools import wraps
+
+def skip_benchmark(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    setattr(wrapper, "skip_benchmark", True)
+    return wrapper

--- a/asv_runner/benchmarks/helpers.py
+++ b/asv_runner/benchmarks/helpers.py
@@ -1,4 +1,37 @@
-from functools import wraps
+import functools
+
+
+def skip_params(skip_params_dict):
+    """
+    Decorator to set skip parameters for a benchmark function.
+
+    #### Parameters
+    **skip_params_dict** (`dict`):
+    A dictionary specifying the skip parameters for the benchmark function.
+    The keys represent the parameter names, and the values can be a single value
+    or a list of values.
+
+    #### Returns
+    **decorator** (`function`):
+    A decorator function that sets the skip parameters for the benchmark function.
+
+    #### Notes
+    The `skip_benchmark_for_params` decorator can be used to specify skip parameters
+    for a benchmark function. The skip parameters define combinations of values that
+    should be skipped when running the benchmark. The decorated function's `skip_params`
+    attribute will be set with the provided skip parameters, which will be used during
+    the benchmarking process.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        setattr(wrapper, "skip_params", skip_params_dict)
+        return wrapper
+
+    return decorator
 
 
 def skip_benchmark(func):
@@ -19,9 +52,13 @@ def skip_benchmark(func):
     benchmarking, it will be skipped and not included in the benchmarking
     process.
     """
-    @wraps(func)
+
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
 
     setattr(wrapper, "skip_benchmark", True)
     return wrapper
+
+
+__all__ = [skip_params, skip_benchmark]

--- a/asv_runner/benchmarks/helpers.py
+++ b/asv_runner/benchmarks/helpers.py
@@ -1,7 +1,7 @@
 import functools
 
 
-def skip_params(skip_params_dict):
+def skip_for_params(skip_params_list):
     """
     Decorator to set skip parameters for a benchmark function.
 
@@ -28,7 +28,7 @@ def skip_params(skip_params_dict):
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
 
-        setattr(wrapper, "skip_params", skip_params_dict)
+        setattr(wrapper, "skip_params", skip_params_list)
         return wrapper
 
     return decorator
@@ -61,4 +61,4 @@ def skip_benchmark(func):
     return wrapper
 
 
-__all__ = [skip_params, skip_benchmark]
+__all__ = [skip_for_params, skip_benchmark]

--- a/asv_runner/benchmarks/helpers.py
+++ b/asv_runner/benchmarks/helpers.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+
 def skip_benchmark(func):
     """
     Decorator to mark a function as skipped for benchmarking.

--- a/asv_runner/benchmarks/helpers.py
+++ b/asv_runner/benchmarks/helpers.py
@@ -1,6 +1,23 @@
 from functools import wraps
 
 def skip_benchmark(func):
+    """
+    Decorator to mark a function as skipped for benchmarking.
+
+    #### Parameters
+    **func** (function)
+    : The function to be marked as skipped.
+
+    #### Returns
+    **wrapper** (function)
+    : A wrapped function that is marked to be skipped for benchmarking.
+
+    #### Notes
+    The `skip_benchmark` decorator can be used to mark a specific function as
+    skipped for benchmarking. When the decorated function is encountered during
+    benchmarking, it will be skipped and not included in the benchmarking
+    process.
+    """
     @wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)

--- a/asv_runner/discovery.py
+++ b/asv_runner/discovery.py
@@ -38,6 +38,10 @@ def _get_benchmark(attr_name, module, klass, func):
     If a match is found, it creates a new benchmark instance and returns it.
     If no match is found, it returns None.
     """
+    # Check if the function has been marked to be skipped
+    if getattr(func, "skip_benchmark", False):
+        return
+
     try:
         name = func.benchmark_name
     except AttributeError:

--- a/asv_runner/discovery.py
+++ b/asv_runner/discovery.py
@@ -30,13 +30,14 @@ def _get_benchmark(attr_name, module, klass, func):
     #### Returns
     **benchmark** (Benchmark instance or None)
     : A benchmark instance with the name of the benchmark, the function to be
-    benchmarked, and its sources. Returns None if no matching benchmark is found.
+    benchmarked, and its sources. Returns None if no matching benchmark is found
+    or the function is marked to be skipped.
 
     #### Notes
-    The function tries to get the `benchmark_name` from `func`. If it fails,
-    it uses `attr_name` to match with the name regex in the benchmark types.
-    If a match is found, it creates a new benchmark instance and returns it.
-    If no match is found, it returns None.
+    The function tries to get the `benchmark_name` from `func`. If it fails, it
+    uses `attr_name` to match with the name regex in the benchmark types.  If a
+    match is found, it creates a new benchmark instance and returns it.  If no
+    match is found or the function is marked to be skipped, it returns None.
     """
     # Check if the function has been marked to be skipped
     if getattr(func, "skip_benchmark", False):


### PR DESCRIPTION
Closes #11 which in turn addresses https://github.com/airspeed-velocity/asv/issues/1299.

```python
from asv_runner.benchmarks.helpers import skip_benchmark

@skip_benchmark
class TimeSuite:
    """
    An example benchmark that times the performance of various kinds
    of iterating over dictionaries in Python.
    """
    def setup(self):
        self.d = {}
        for x in range(500):
            self.d[x] = None

    def time_keys(self):
        for key in self.d.keys():
            pass

    def time_values(self):
        for value in self.d.values():
            pass

    def time_range(self):
        d = self.d
        for key in range(500):
            d[key]
```

The whole class will be skipped. Individual functions can also be skipped.