### PR TITLE
ENH: Add a `skip_benchmark_if` and `skip_params_if`

### DIFF
--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -61,4 +61,5 @@ def skip_benchmark(func):
     return wrapper
 
 
+
 __all__ = [skip_for_params, skip_benchmark]

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -93,4 +93,39 @@ def skip_benchmark_if(condition):
     return decorator
 
 
-__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if"]
+def skip_params_if(skip_params_list, condition):
+    """
+    Decorator to set skip parameters for a benchmark function if a condition is met.
+
+    #### Parameters
+    **skip_params_list** (`list`):
+    A list specifying the skip parameters for the benchmark function.
+
+    **condition** (`bool`)
+    : A boolean that indicates whether to set the skip parameters. If `True`,
+      the skip parameters will be set for the decorated function. If `False`,
+      no parameters will be skipped.
+
+    #### Returns
+    **decorator** (function):
+    A decorator function that sets the skip parameters for the benchmark function
+      if the condition is met.
+
+    #### Notes
+    The `skip_params_if` decorator can be used to specify skip parameters for a
+      benchmark function if a condition is met.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        if condition:
+            setattr(wrapper, "skip_params", skip_params_list)
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if"]

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -61,5 +61,36 @@ def skip_benchmark(func):
     return wrapper
 
 
+def skip_benchmark_if(condition):
+    """
+    Decorator to skip benchmarking of a function if a condition is met.
 
-__all__ = [skip_for_params, skip_benchmark]
+    #### Parameters
+    **condition** (`bool`)
+    : A boolean that indicates whether to skip benchmarking. If `True`,
+      the decorated function will be skipped for benchmarking. If `False`,
+      the decorated function will be benchmarked as usual.
+
+    #### Returns
+    **decorator** (function)
+    : A decorator function that sets the condition under which the decorated function
+      will be skipped for benchmarking.
+
+    #### Notes
+    The `skip_if` decorator can be used to skip the benchmarking of a specific function
+    if a condition is met.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        if condition:
+            setattr(wrapper, "skip_benchmark", True)
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if"]


### PR DESCRIPTION
Closes #16.

```python
from asv_runner.benchmarks.mark import skip_benchmark_if, skip_params_if
import datetime

class TimeSuite:
    """
    An example benchmark that times the performance of various kinds
    of iterating over dictionaries in Python.
    """
    params = [100, 200, 300, 400, 500]
    param_names = ["size"]

    def setup(self, size):
        self.d = {}
        for x in range(size):
            self.d[x] = None

    @skip_benchmark_if(datetime.datetime.now().hour >= 12)
    def time_keys(self, size):
        for key in self.d.keys():
            pass

    @skip_benchmark_if(datetime.datetime.now().hour >= 12)
    def time_values(self, size):
        for value in self.d.values():
            pass

    @skip_benchmark_if(datetime.datetime.now().hour >= 12)
    def time_range(self, size):
        d = self.d
        for key in range(size):
            d[key]

    # Skip benchmarking when size is either 100 or 200 and the current hour is 12 or later.
    @skip_params_if([(100,), (200,)],
                    datetime.datetime.now().hour >= 12)
    def time_dict_update(self, size):
        d = self.d
        for i in range(size):
            d[i] = i
```