### PR TITLE
ENH: `pytest` style parameter decorators

### DIFF
--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -155,7 +155,7 @@ def parameterize_class_with(param_dict):
             raise TypeError("The parameterize_class_with decorator can only be used with classes")
         # Handle the single parameter case separately.
         if len(param_dict) > 1:
-            cls.params = list(zip(*param_dict.values()))
+            cls.params = list(param_dict.values())
         else:
             cls.params = list(param_dict.values())[0]
         cls.param_names = list(param_dict.keys())

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 
 
 def skip_for_params(skip_params_list):
@@ -128,40 +129,34 @@ def skip_params_if(skip_params_list, condition):
     return decorator
 
 
-def parameterize_with(params, param_names):
+def parameterize_class_with(param_dict):
     """
-    Decorator to set benchmark parameters for a function.
+    Class Decorator to set benchmark parameters for a class.
 
     #### Parameters
-    **params** (`list`):
-    A list specifying the parameters for the benchmark function.
-
-    **param_names** (`list`)
-    : A list specifying the names of the parameters. The length of `param_names`
-      should match the length of `params`.
+    **param_dict** (`dict`):
+    A dictionary specifying the parameters for the benchmark class.
+    The keys represent the parameter names, and the values are lists
+    of values for those parameters.
 
     #### Returns
     **decorator** (function):
-    A decorator function that sets the parameters for the benchmark function.
+    A class decorator that sets the parameters for the benchmark functions.
 
     #### Notes
-    The `parameterize_with` decorator can be used to specify parameters for a
-    benchmark function. The parameters are defined as a list of values and the
-    corresponding parameter names are defined as a list of strings. The decorated
-    function's `params` and `param_names` attributes will be set with the provided
+    The `parameterize_class_with` decorator can be used to specify parameters for a
+    benchmark class. The parameters are defined as a dictionary, where keys are
+    the parameter names and values are lists of respective values. The decorated
+    class's `params` and `param_names` attributes will be set with the provided
     parameters and names, which will be used during the benchmarking process.
     """
-
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        setattr(wrapper, "params", params)
-        setattr(wrapper, "param_names", param_names)
-        return wrapper
-
+    def decorator(cls):
+        if not inspect.isclass(cls):
+            raise TypeError("The parameterize_class_with decorator can only be used with classes")
+        cls.params = list(zip(*param_dict.values()))
+        cls.param_names = list(param_dict.keys())
+        return cls
     return decorator
 
 
-__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if", "parameterize_with"]
+__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if", "parameterize_class_with"]

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -128,4 +128,40 @@ def skip_params_if(skip_params_list, condition):
     return decorator
 
 
-__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if"]
+def parameterize_with(params, param_names):
+    """
+    Decorator to set benchmark parameters for a function.
+
+    #### Parameters
+    **params** (`list`):
+    A list specifying the parameters for the benchmark function.
+
+    **param_names** (`list`)
+    : A list specifying the names of the parameters. The length of `param_names`
+      should match the length of `params`.
+
+    #### Returns
+    **decorator** (function):
+    A decorator function that sets the parameters for the benchmark function.
+
+    #### Notes
+    The `parameterize_with` decorator can be used to specify parameters for a
+    benchmark function. The parameters are defined as a list of values and the
+    corresponding parameter names are defined as a list of strings. The decorated
+    function's `params` and `param_names` attributes will be set with the provided
+    parameters and names, which will be used during the benchmarking process.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        setattr(wrapper, "params", params)
+        setattr(wrapper, "param_names", param_names)
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if", "parameterize_with"]

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -152,9 +152,12 @@ def parameterize_class_with(param_dict):
     This decorator will overwrite any existing `params` and `param_names`
     attributes in the class.
     """
+
     def decorator(cls):
         if not inspect.isclass(cls):
-            raise TypeError("The parameterize_class_with decorator can only be used with classes")
+            raise TypeError(
+                "The parameterize_class_with decorator can only be used with classes"
+            )
         # Handle the single parameter case separately.
         if len(param_dict) > 1:
             cls.params = list(param_dict.values())
@@ -162,6 +165,7 @@ def parameterize_class_with(param_dict):
             cls.params = list(param_dict.values())[0]
         cls.param_names = list(param_dict.keys())
         return cls
+
     return decorator
 
 
@@ -188,16 +192,62 @@ def parameterize_func_with(param_dict):
     This decorator will overwrite any existing `params` and `param_names`
     attributes in the function, and it should not be used with methods of a class.
     """
+
     def decorator(func):
         if inspect.isclass(func) or inspect.ismethod(func):
-            raise TypeError("The parameterize_func_with decorator can only be used with functions")
+            raise TypeError(
+                "The parameterize_func_with decorator can only be used with functions"
+            )
         if len(param_dict) > 1:
             func.params = list(param_dict.values())
         else:
             func.params = list(param_dict.values())[0]
         func.param_names = list(param_dict.keys())
         return func
+
     return decorator
 
 
-__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if", "parameterize_class_with", "parameterize_func_with"]
+def parameterize(param_dict):
+    """
+    Decorator to set benchmark parameters for a function or a class.
+
+    #### Parameters
+    **param_dict** (`dict`):
+    A dictionary specifying the parameters for the benchmark.
+    The keys represent the parameter names, and the values are lists
+    of values for those parameters.
+
+    #### Returns
+    **decorator** (function):
+    A function or class decorator that sets the parameters for the benchmark.
+
+    #### Notes
+    The `parameterize` decorator can be used to specify parameters for a
+    benchmark function or class. The parameters are defined as a dictionary,
+    where keys are the parameter names and values are lists of respective values.
+    The decorated function or class's `params` and `param_names` attributes
+    will be set with the provided parameters and names, which will be used
+    during the benchmarking process.
+    """
+
+    def decorator(obj):
+        if inspect.isclass(obj):
+            return parameterize_class_with(param_dict)(obj)
+        elif callable(obj):
+            return parameterize_func_with(param_dict)(obj)
+        else:
+            raise TypeError(
+                "The parameterize decorator can only be used with functions or classes"
+            )
+
+    return decorator
+
+
+__all__ = [
+    "skip_for_params",
+    "skip_benchmark",
+    "skip_benchmark_if",
+    "skip_params_if",
+    "parameterize",
+]

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -149,6 +149,8 @@ def parameterize_class_with(param_dict):
     the parameter names and values are lists of respective values. The decorated
     class's `params` and `param_names` attributes will be set with the provided
     parameters and names, which will be used during the benchmarking process.
+    This decorator will overwrite any existing `params` and `param_names`
+    attributes in the class.
     """
     def decorator(cls):
         if not inspect.isclass(cls):
@@ -162,4 +164,40 @@ def parameterize_class_with(param_dict):
         return cls
     return decorator
 
-__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if", "parameterize_class_with"]
+
+def parameterize_func_with(param_dict):
+    """
+    Function Decorator to set benchmark parameters for a function.
+
+    #### Parameters
+    **param_dict** (`dict`):
+    A dictionary specifying the parameters for the benchmark function.
+    The keys represent the parameter names, and the values are lists
+    of values for those parameters.
+
+    #### Returns
+    **decorator** (function):
+    A function decorator that sets the parameters for the benchmark function.
+
+    #### Notes
+    The `parameterize_func_with` decorator can be used to specify parameters for a
+    benchmark function. The parameters are defined as a dictionary, where keys are
+    the parameter names and values are lists of respective values. The decorated
+    function's `params` and `param_names` attributes will be set with the provided
+    parameters and names, which will be used during the benchmarking process.
+    This decorator will overwrite any existing `params` and `param_names`
+    attributes in the function, and it should not be used with methods of a class.
+    """
+    def decorator(func):
+        if inspect.isclass(func) or inspect.ismethod(func):
+            raise TypeError("The parameterize_func_with decorator can only be used with functions")
+        if len(param_dict) > 1:
+            func.params = list(param_dict.values())
+        else:
+            func.params = list(param_dict.values())[0]
+        func.param_names = list(param_dict.keys())
+        return func
+    return decorator
+
+
+__all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if", "parameterize_class_with", "parameterize_func_with"]

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -153,10 +153,13 @@ def parameterize_class_with(param_dict):
     def decorator(cls):
         if not inspect.isclass(cls):
             raise TypeError("The parameterize_class_with decorator can only be used with classes")
-        cls.params = list(zip(*param_dict.values()))
+        # Handle the single parameter case separately.
+        if len(param_dict) > 1:
+            cls.params = list(zip(*param_dict.values()))
+        else:
+            cls.params = list(param_dict.values())[0]
         cls.param_names = list(param_dict.keys())
         return cls
     return decorator
-
 
 __all__ = ["skip_for_params", "skip_benchmark", "skip_benchmark_if", "skip_params_if", "parameterize_class_with"]


### PR DESCRIPTION
Implements one of the most requested features, closing out https://github.com/airspeed-velocity/asv/issues/482 and https://github.com/airspeed-velocity/asv/issues/1266. Depends on #17 being merged.

Needs a documentation PR at `asv` as well, but the usage is essentially:

```python
import numpy as np
from asv_runner.benchmarks.mark import parameterize

@parameterize({"n":[10, 100]})
def time_sort(n):
    np.sort(np.random.rand(n))

@parameterize({'n': [10, 100], 'func_name': ['range', 'arange']})
def time_ranges_multi(n, func_name):
    f = {'range': range, 'arange': np.arange}[func_name]
    for i in f(n):
        pass

@parameterize({"size": [10, 100, 200]})
class TimeSuiteDecoratorSingle:
    def setup(self, size):
        self.d = {}
        for x in range(size):
            self.d[x] = None

    def time_keys(self, size):
        for key in self.d.keys():
            pass

    def time_values(self, size):
        for value in self.d.values():
            pass

@parameterize({'n': [10, 100], 'func_name': ['range', 'arange']})
class TimeSuiteMultiDecorator:
    def time_ranges(self, n, func_name):
        f = {'range': range, 'arange': np.arange}[func_name]
        for i in f(n):
            pass
```

Not implementing the ability to pass `params` without names is by design.