### PR TITLE
ENH: Skip during benchmark execution

### DIFF
--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -2,6 +2,61 @@ import functools
 import inspect
 
 
+class SkipNotImplemented(NotImplementedError):
+    """
+    Exception raised to indicate a skipped benchmark.
+
+    This exception inherits from `NotImplementedError`. It's used within an ASV
+    benchmark to skip the current benchmark for certain parameters or conditions
+    that are not implemented or do not apply.
+
+    #### Attributes
+    **message** (`str`)
+    : A string that provides a more detailed explanation of the skip reason.
+
+    #### Warning
+    Use of `SkipNotImplemented` is less efficient than the `@skip_for_params`
+    decorator as the setup for the benchmarks and the benchmarks themselves are
+    run before the error is raised, thus consuming unnecessary resources. Use
+    `@skip_for_params` where possible to avoid running the benchmarks that
+    should be skipped.
+
+    #### Notes
+    This is mainly provided for backwards compatibility with the behavior of asv
+    before 0.5 wherein individual benchmarks could raise and be skipped. From
+    0.5 onwards, only the setup function is meant to raise `NotImplemented` for
+    skipping parameter sets.
+
+    #### Example
+    This exception might be used in a scenario where a benchmark should be
+    skipped for certain conditions or parameters:
+
+    ```{code-block} python
+    class Simple:
+        params = ([False, True])
+        param_names = ["ok"]
+
+        def time_failure(self, ok):
+            if ok:
+                x = 34.2**4.2
+            else:
+                raise SkipNotImplemented
+    ```
+    """
+
+    def __init__(self, message=""):
+        """
+        Initialize a new instance of `SkipNotImplemented`.
+
+        #### Parameters
+        **message** (`str`)
+        : A string that provides a more detailed explanation of the skip reason.
+          Optional; if not provided, defaults to an empty string.
+        """
+        self.message = message
+        super().__init__(self.message)
+
+
 def skip_for_params(skip_params_list):
     """
     Decorator to set skip parameters for a benchmark function.

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -245,6 +245,24 @@ def parameterize(param_dict):
 
 
 def timeout_class_at(seconds):
+    """
+    Class Decorator to set timeout for a class.
+
+    #### Parameters
+    **seconds** (`float`)
+    : The number of seconds after which the class methods should be timed out.
+
+    #### Returns
+    **decorator** (function)
+    : A class decorator that sets the timeout for the class.
+
+    #### Notes
+    The `timeout_class_at` decorator can be used to specify a timeout for all
+    methods in a class. The timeout is stored as an attribute on the class and
+    applies to all its methods. Individual methods can override this timeout by
+    using the `timeout_func_at` or `timeout_at` decorators.
+    """
+
     def decorator(cls):
         if not inspect.isclass(cls):
             raise TypeError(
@@ -257,6 +275,24 @@ def timeout_class_at(seconds):
 
 
 def timeout_func_at(seconds):
+    """
+    Function Decorator to set timeout for a function.
+
+    #### Parameters
+    **seconds** (`float`)
+    : The number of seconds after which the function should be timed out.
+
+    #### Returns
+    **decorator** (function)
+    : A function decorator that sets the timeout for the function.
+
+    #### Notes
+    The `timeout_func_at` decorator can be used to specify a timeout for a
+    specific function. This is particularly useful for benchmarking, where you
+    might want to stop execution of functions that take too long. The timeout is
+    stored as an attribute on the function.
+    """
+
     def decorator(func):
         if inspect.isclass(func):
             raise TypeError(
@@ -274,6 +310,27 @@ def timeout_func_at(seconds):
 
 
 def timeout_at(seconds):
+    """
+    Decorator to set a timeout for a function or a class.
+
+    #### Parameters
+    **seconds** (`float`)
+    : The number of seconds after which the function or the class methods should
+    be timed out.
+
+    #### Returns
+    **decorator** (function)
+    : A decorator that sets the timeout for the function or the class.
+
+    #### Notes
+    The `timeout_at` decorator can be used to set a specific timeout for a
+    function or all methods in a class. If applied to a class, the timeout is
+    stored as an attribute on the class and applies to all its methods.
+    Individual methods can override this timeout by using the `timeout_func_at`
+    or `timeout_at` decorators. If applied to a function, the timeout is stored
+    directly on the function.
+    """
+
     def decorator(obj):
         if inspect.isclass(obj):
             return timeout_class_at(seconds)(obj)

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -244,10 +244,54 @@ def parameterize(param_dict):
     return decorator
 
 
+def timeout_class_at(seconds):
+    def decorator(cls):
+        if not inspect.isclass(cls):
+            raise TypeError(
+                "The timeout_class_with decorator can only be used with classes"
+            )
+        cls.timeout = seconds
+        return cls
+
+    return decorator
+
+
+def timeout_func_at(seconds):
+    def decorator(func):
+        if inspect.isclass(func):
+            raise TypeError(
+                "The timeout_func_with decorator can only be used with functions"
+            )
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        setattr(wrapper, "timeout", seconds)
+        return wrapper
+
+    return decorator
+
+
+def timeout_at(seconds):
+    def decorator(obj):
+        if inspect.isclass(obj):
+            return timeout_class_at(seconds)(obj)
+        elif callable(obj):
+            return timeout_func_at(seconds)(obj)
+        else:
+            raise TypeError(
+                "The parameterize decorator can only be used with functions or classes"
+            )
+
+    return decorator
+
+
 __all__ = [
     "skip_for_params",
     "skip_benchmark",
     "skip_benchmark_if",
     "skip_params_if",
     "parameterize",
+    "timeout_at",
 ]

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -421,10 +421,10 @@ def timeout_at(seconds):
 
 
 __all__ = [
-    "skip_for_params",
+    "parameterize",
     "skip_benchmark",
     "skip_benchmark_if",
+    "skip_for_params",
     "skip_params_if",
-    "parameterize",
     "timeout_at",
 ]

--- a/asv_runner/benchmarks/mark.py
+++ b/asv_runner/benchmarks/mark.py
@@ -62,21 +62,41 @@ def skip_for_params(skip_params_list):
     Decorator to set skip parameters for a benchmark function.
 
     #### Parameters
-    **skip_params_dict** (`dict`):
-    A dictionary specifying the skip parameters for the benchmark function.
-    The keys represent the parameter names, and the values can be a single value
-    or a list of values.
+    **skip_params_list** (`list`):
+    A list of tuples, each specifying a combination of parameter values that
+    should cause the benchmark function to be skipped.
 
     #### Returns
     **decorator** (`function`):
-    A decorator function that sets the skip parameters for the benchmark function.
+    A decorator function that sets the skip parameters for the benchmark
+    function.
 
     #### Notes
-    The `skip_benchmark_for_params` decorator can be used to specify skip parameters
-    for a benchmark function. The skip parameters define combinations of values that
-    should be skipped when running the benchmark. The decorated function's `skip_params`
-    attribute will be set with the provided skip parameters, which will be used during
-    the benchmarking process.
+    The `skip_for_params` decorator can be used to specify conditions under
+    which a benchmark function should be skipped. Each tuple in the list
+    represents a combination of parameter values which, if received by the
+    benchmark function, will cause that function to be skipped during the
+    benchmarking process.
+
+    The decorated function's `skip_params` attribute will be set with the
+    provided skip parameters, which will be used during the benchmarking
+    process.
+
+    Using this decorator is always more efficient than raising a
+    `SkipNotImplemented` exception within the benchmark function, as the
+    function setup and execution can be avoided entirely for skipped parameters.
+
+    #### Example
+    ```{code-block} python
+    class Simple:
+        params = ([False, True])
+        param_names = ["ok"]
+
+        @skip_for_params([(False, )])
+        def time_failure(self, ok):
+            if ok:
+                x = 34.2**4.2
+    ```
     """
 
     def decorator(func):
@@ -133,8 +153,9 @@ def skip_benchmark_if(condition):
       will be skipped for benchmarking.
 
     #### Notes
-    The `skip_if` decorator can be used to skip the benchmarking of a specific function
-    if a condition is met.
+    The `skip_if` decorator can be used to skip the benchmarking of a specific
+    function if a condition is met. It is faster than raising
+    `SkipNotImplemented` as it skips the `setup()` as well.
     """
 
     def decorator(func):

--- a/asv_runner/run.py
+++ b/asv_runner/run.py
@@ -3,6 +3,7 @@ import math
 import pickle
 
 from ._aux import set_cpu_affinity_from_params
+from .benchmarks.mark import SkipNotImplemented
 from .discovery import get_benchmark_from_name
 
 
@@ -67,9 +68,13 @@ def _run(args):
         if skip:
             result = math.nan
         else:
-            result = benchmark.do_run()
-            if profile_path is not None:
-                benchmark.do_profile(profile_path)
+            try:
+                result = benchmark.do_run()
+                if profile_path is not None:
+                    benchmark.do_profile(profile_path)
+            except SkipNotImplemented:
+                # Still runs setup() though
+                result = math.nan
     finally:
         benchmark.do_teardown()
 


### PR DESCRIPTION
Closes https://github.com/airspeed-velocity/asv/issues/1028. Associated `asv` documentation update:: https://github.com/airspeed-velocity/asv/pull/1309.

```python
from asv_runner.benchmarks.mark import skip_for_params, parameterize, SkipNotImplemented

# Fast because no setup is called
class SimpleFast:
    params = ([False, True])
    param_names = ["ok"]

    @skip_for_params([(False, )])
    def time_failure(self, ok):
        if ok:
            x = 34.2**4.2

@parameterize({"ok": [False, True]})
class SimpleSlow:
    def time_failure(self, ok):
        if ok:
            x = 34.2**4.2
        else:
            raise SkipNotImplemented(f"{ok} is skipped")
```