### PR TITLE
MAINT: Pin dependencies for read-the-docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,7 @@ formats:
   - epub
 python:
   install:
+    - requirements: docs/requirements.txt
     - method: pip
       path: .
       extra_requirements:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,9 @@
+sphinx==7.2.2
+furo==2023.08.19
+sphinx-copybutton==0.5.2
+sphinx-contributors==0.2.7
+sphinx_design==0.5.0
+sphinx-autobuild==2021.3.14
+sphinxcontrib-spelling==8.0.0
+myst-parser==2.0.0
+sphinx-autodoc2==0.4.2


### PR DESCRIPTION
Needed to fix RTD builds.