### PR TITLE
Fix bug in `asv_runner.benchmarks`

### DIFF
--- a/asv_runner/benchmarks/__init__.py
+++ b/asv_runner/benchmarks/__init__.py
@@ -49,9 +49,8 @@ submodule_names = [
     name for _, name, _ in pkgutil.iter_modules(pkgpath) if "_" not in name
 ]
 asv_modules = [
-    dist.metadata["Name"]
-    for dist in distributions()
-    if dist.metadata["Name"].startswith("asv_bench")
+    name for dist in distributions()
+    if isinstance(name := dist.metadata.get("Name", None), str) and name.startswith("asv_bench")
 ]
 benchmark_types = []
 

--- a/asv_runner/benchmarks/__init__.py
+++ b/asv_runner/benchmarks/__init__.py
@@ -49,8 +49,10 @@ submodule_names = [
     name for _, name, _ in pkgutil.iter_modules(pkgpath) if "_" not in name
 ]
 asv_modules = [
-    name for dist in distributions()
-    if isinstance(name := dist.metadata.get("Name", None), str) and name.startswith("asv_bench")
+    name
+    for dist in distributions()
+    if isinstance(name := dist.metadata.get("Name", None), str)
+    and name.startswith("asv_bench")
 ]
 benchmark_types = []
 


### PR DESCRIPTION
Resolves #41

The proposed implementation also avoids a `DeprecationWarning` from `importlib-metadata` 7 and a `KeyError` exception in version 8.