### PR TITLE
fix: timeraw with params doesn't use the returned script string

### DIFF
--- a/asv_runner/benchmarks/timeraw.py
+++ b/asv_runner/benchmarks/timeraw.py
@@ -136,7 +136,7 @@ class TimerawBenchmark(TimeBenchmark):
         if param:
 
             def func():
-                self.func(*param)
+                return self.func(*param)
 
         else:
             func = self.func


### PR DESCRIPTION
When I defined a `timeraw` function with params, the script string returned from the test function was not being picked up.

```py
class DjangoComponentsVsDjangoSuite:
    @benchmark(
        pretty_name="startup - large",
        benchmark_name=f"{DJC_VS_DJ_GROUP}.timeraw_startup_lg",
        params=[(1, 2, 3)],
        param_names=["num"],
    )
    def timeraw_import_inspect1(self, num: int):
        return """import inspect"""
```